### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@
 
 Your friendly neighborhood `seapig` is here to help you maintain consistent rendering structure for your React Components. It retrieves designated props from children, ensures all corresponding children are provided, then renders them in a pre-determined order.
 
-Good ol' `seapig` restricts this consistent shape by enforcing [**Rendering Order**](#RenderingOrder) and [**Child Presence**](#ChildPresence):
+Good ol' `seapig` restricts this consistent shape by enforcing [**Rendering Order**](#RenderingOrder) and [**Child Presence**](#ChildPresence).
 
-The main idea is to promote a cleaner rendering structure
-by requiring components that can (or must) be rendered together to be provided externally as children rather than passing them as props:
+The main idea is to promote a cleaner rendering structure by requiring components that can (or must) be rendered together to be provided externally as children rather than passing them as props:
 
-```jsx
+```js
 /* No more need for this */
 <Button label={<span>Click Me</span>} icon={<i className="fa" />} />
 
@@ -24,11 +23,13 @@ by requiring components that can (or must) be rendered together to be provided e
 </Button>
 ```
 
+This not only allows a cleaner JSX layout but also decouples child specific properties such as tag name or class name, allowing external users to freely specify them.
+
 ### <a name="RenderingOrder">Rendering Order</a>
 
 Children are rendered into special placeholders determined by the provided props. This means that the rendering shape is enforced internally, allowing us to pass the children into a `seapig` component in any order.
 
-```jsx
+```js
 /* `MyCoolSidebar` and `Content` are always rendered in the same order no matter what order they are passed in */
 
 /* This one would render the same */
@@ -74,7 +75,7 @@ A `seapig` component ensures that all children identified by the required props 
 
 To reuse `<Main>` from above as an example, if we didn't pass one or more of its children with the required props (`'content'` or `'sidebar'`), `seapig` would throw:
 
-```jsx
+```js
 // The code bellow would throw a "Missing required prop `sidebar`" error
 <Main>
   <Content content>
@@ -85,7 +86,7 @@ To reuse `<Main>` from above as an example, if we didn't pass one or more of its
 
 The `seapig` also ensures that there are no rogue unidentified children, unless we tell it explicitly that we are expecting a single child without an identifying prop.
 
-```jsx
+```js
 import seapig, { DEFAULT_CHILD } from 'seapig'
 
 const Main = props => {
@@ -108,7 +109,7 @@ const Main = props => {
   )
 }
 
-/* Allows us to not need to specify an identifying prop on one of the children */
+/* Now we don't need to specify an identifying prop on one of the children */
 <Main>
   <Content content>
     <h2>Hello `seapig`!</h2>
@@ -132,7 +133,7 @@ npm install seapig --save
 
 ### `seapig` button with a required label and an optional icon:
 
-```jsx
+```js
 import React, { Component } from 'react'
 import seapig from 'seapig'
 
@@ -179,13 +180,13 @@ class Form extends Component {
 ```js
 const {
   icon,
-  [DEFAULT_CHILD]: proplessChild, // the single allowed child without any props to get
+  [DEFAULT_CHILD]: anyChild, // the single allowed child without any specific designate props
   label,
 } = seapig(children, {
   // optional children prop names are denoted in the `optional` array
   optional: ['icon', DEFAULT_CHILD],
   // required children prop names are denoted in the `required` array
-  required: ['label'] // code will throw if no label was passed
+  required: ['label'] // code will throw if no child with the `label` prop was passed because it's required
 })
 ```
 


### PR DESCRIPTION
Add an extra sentence explaining the benefit of decoupling children, which allows independent customization of `seapig` children externally.

Also change `jsx` readme tags to `js` because NPM doesn't support `jsx`.