### PR TITLE
validate that elements have at most 1 seapig prop

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -110,4 +110,13 @@ describe('seapig', () => {
       seapig(children, null)
     }).toThrow('schema must be an object')
   })
+  test(`should throw when an element has multiple matching props`, () => {
+    const invalidChildren = [<div whatever other />]
+    expect(() => {
+      seapig(invalidChildren, {
+        [PROP]: OPTIONAL,
+        other: OPTIONAL
+      })
+    }).toThrow('expected at most 1 seapig prop per element but found 2 (whatever, other) for child at index 0');
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -77,12 +77,14 @@ export default function seapig(children: Node, schema: SeaPigSchema = {}): SeaPi
   );
 
   // build the result
-  Children.toArray(children).forEach(child => {
+  Children.toArray(children).forEach((child, i) => {
     if (!child) {
       return;
     }
-    const propName: string = propNames.find(p => child.props[p]) || REST;
-    result[propName === REST ? propName : convertPropName(propName)].push(child);
+    const matchingPropNames: Array<string> = propNames.filter(p => child.props[p]);
+    invariant(matchingPropNames.length <= 1, `expected at most 1 seapig prop per element but found ${matchingPropNames.length} (${matchingPropNames.join(', ')}) for child at index ${i}`);
+    const propName: ?string = matchingPropNames[0];
+    result[propName ? convertPropName(propName) : REST].push(child);
   });
 
   // validate the result


### PR DESCRIPTION
I imagine at some point someone will accidentally add more than 1 seapig prop to an element. If that were to happen, currently it will just use whichever prop matches first and silently ignore any other matching props, which could be troublesome to debug.

This change makes seapig throw if more than one matching prop is found, although I don't know if that's how you want to handle it.

An alternative would be to fully support adding multiple seapig props to an element and have that element be included in multiple child arrays like so:

```js
const children = [<div propA propB />];
const result = seapig(children, {
  propA: OPTIONAL,
  propB: OPTIONAL,
});
expect(result.propAChildren.length).toBe(1);
expect(result.propBChildren.length).toBe(1);
```

Either way, it feels like it would be beneficial to have a more well-defined behavior if/when this situation occurs.