### PR TITLE
🛠 Fix: Publish TS declaration file to npm as well, fix some types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'seapig' {
-  import { ReactElement } from 'react';
+  import { ReactNode } from 'react';
 
   interface ValidationConfiguration {
     min?: number;
@@ -11,13 +11,13 @@ declare module 'seapig' {
   }
 
   interface Result {
-    [key: string]: ReactElement[];
-    rest: ReactElement[];
+    [key: string]: ReactNode;
+    rest: ReactNode;
   }
 
   export default function seapig(
-    children: ReactElement[],
-    schema: Schema,
+    children?: ReactNode | null,
+    schema?: Schema,
   ): Result;
 
   export const OPTIONAL: ValidationConfiguration;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   ],
   "files": [
     "es",
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "author": "Nemanja Stojanovic <me@nem035.com>",
   "license": "MIT",


### PR DESCRIPTION
## Add TS module

I've noticed that the TS module declaration file `index.d.ts` is not included in the final bundle published to npm.

```bash
> ls node_modules/seapig
> LICENSE      README.md    dist         es           package.json
```

So I added it on the `files` keyword in the package.json, which according to the [docs](https://classic.yarnpkg.com/en/docs/package-json/#toc-files) should do the trick 🤞 
 ## Fix Element types
The right way to type components I found was actually using `ReactNode` instead of `Element`
